### PR TITLE
Convert documentation erroneously lists "ton" as a mass unit when it's a power one

### DIFF
--- a/docs/reference/measure_code_examples.md
+++ b/docs/reference/measure_code_examples.md
@@ -61,7 +61,7 @@ You can use the `*` (multiply), `/` (divide), and `^` (exponent) operators in th
   </tr>
   <tr>
     <td>Mass</td>
-    <td>"lb_m", "ton"</td>
+    <td>"lb_m"</td>
     <td>"kg"</td>
   </tr>
   <tr>
@@ -81,7 +81,7 @@ You can use the `*` (multiply), `/` (divide), and `^` (exponent) operators in th
   </tr>
   <tr>
     <td>Power</td>
-    <td>"ft\*lb_f/s"</td>
+    <td>"ft\*lb_f/s", "Btu/h", "ton"</td>
     <td>"W"</td>
   </tr>
   <tr>


### PR DESCRIPTION
Reported on slack by  @eringold